### PR TITLE
Made ma_context_init use OpenSL|ES on Android by default to avoid bugs with the AAudio backend for miniaudio.

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -487,7 +487,13 @@ void InitAudioDevice(void)
     ma_context_config contextConfig = ma_context_config_init();
     contextConfig.logCallback = OnLog;
     
+    #ifdef __ANDROID__
+    ma_backend android_opensl_backend[] = { ma_backend_opensl };
+    ma_result result = ma_context_init(android_opensl_backend, 1, &contextConfig, &context);
+    #else 
     ma_result result = ma_context_init(NULL, 0, &contextConfig, &context);
+    #endif
+    
     if (result != MA_SUCCESS)
     {
         TraceLog(LOG_ERROR, "Failed to initialize audio context");


### PR DESCRIPTION
I identified a possible bug with the AAudio backend for miniaudio in which an assertion from miniaudio fails when the user leaves and comes back to the app.

Miniaudio issue: https://github.com/dr-soft/miniaudio/issues/103

For now, I suggest this fix, a simple #ifdef that initializes miniaudio with the OpenSL|ES backend on Android since from my tests the OpenSL|ES backend doesn't have this issue.