### PR TITLE
Update raudio.h and raudio.c

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -81,7 +81,7 @@
     #include "utils.h"          // Required for: fopen() Android mapping
 #endif
 
-#if defined(SUPPORT_MODULE_RAUDIO)
+#if defined(SUPPORT_MODULE_RAUDIO) || defined(RAUDIO_STANDALONE)
 
 #if defined(_WIN32)
 // To avoid conflicting windows.h symbols with raylib, some flags are defined

--- a/src/raudio.h
+++ b/src/raudio.h
@@ -73,13 +73,14 @@
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
-#ifndef __cplusplus
-// Boolean type
-    #if !defined(_STDBOOL_H)
-        typedef enum { false, true } bool;
-        #define _STDBOOL_H
-    #endif
+#if (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+    #include <stdbool.h>
+#elif !defined(__cplusplus) && !defined(bool)
+    typedef enum bool { false = 0, true = !false } bool;
+    #define RL_BOOL_TYPE
 #endif
+
+typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
 
 // Wave, audio wave data
 typedef struct Wave {
@@ -91,6 +92,7 @@ typedef struct Wave {
 } Wave;
 
 typedef struct rAudioBuffer rAudioBuffer;
+typedef struct rAudioProcessor rAudioProcessor;
 
 // AudioStream, custom audio stream
 typedef struct AudioStream {
@@ -167,7 +169,7 @@ void UnloadWaveSamples(float *samples);                         // Unload sample
 
 // Music management functions
 Music LoadMusicStream(const char *fileName);                    // Load music stream from file
-Music LoadMusicStreamFromMemory(const char *fileType, unsigned char* data, int dataSize); // Load music stream from data
+Music LoadMusicStreamFromMemory(const char *fileType, const unsigned char* data, int dataSize); // Load music stream from data
 void UnloadMusicStream(Music music);                            // Unload music stream
 void PlayMusicStream(Music music);                              // Start music playing
 bool IsMusicStreamPlaying(Music music);                         // Check if music is playing


### PR DESCRIPTION
### Problem description
When compiling the library example (es. __raudio_standalone.c__) in standalone mode, a lot of "Undefined reference" errors pop-up.

### Solution
By changing the __raudio.c__ precompiler ```#if``` guard from
```c
#if defined(SUPPORT_MODULE_RAUDIO)
```
 to
```c
#if defined(SUPPORT_MODULE_RAUDIO) || defined(RAUDIO_STANDALONE)
```
the issue seems to be fixed.

Also, to properly compile the library, some __raudio.h__ definitions were updated, in particular:
  - The ```bool``` definition was aligned to the current definition in __raylib.h__;
  - The ```AudioCallback```definition was added;
  - The ```rAudioProcessor``` definition was added.

### Should Fix
If I understood the problem correctly, this pull request should also fix issue #5.

___

P.s. Apologies for the "precompiler" typo in the commit message, it should be "preprocessor"... 😵‍💫