### PR TITLE
Update raudio.c

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -81,7 +81,7 @@
     #include "utils.h"          // Required for: fopen() Android mapping
 #endif
 
-#if defined(SUPPORT_MODULE_RAUDIO)
+#if defined(SUPPORT_MODULE_RAUDIO) || defined(RAUDIO_STANDALONE)
 
 #if defined(_WIN32)
 // To avoid conflicting windows.h symbols with raylib, some flags are defined


### PR DESCRIPTION
Recommitted a fix that was applied a couple of years ago to handle a bunch of undefined references when attempting to use raudio in standalone mode.  I don't know if this change was applied for another reason, if so just ignore.