### PR TITLE
Fix incorrect libm linking on VS2022 in CMake project

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -41,9 +41,11 @@ target_compile_definitions(raudio PUBLIC
 )
 
 # Dependenices
-target_link_libraries(raudio
-    m # math
-)
+if(NOT MSVC)
+    target_link_libraries(raudio
+        m # math
+    )
+endif()
 
 # Audio file support options
 if (SUPPORT_FILEFORMAT_WAV)

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -18,6 +18,7 @@ set(RAUDIO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 set(RAUDIO_SRC ${RAUDIO_ROOT}/src)
 set(RAUDIO_EXAMPLES ${RAUDIO_ROOT}/examples)
 
+option(DISABLE_DEFAULT_LOG "Disable default logging" ON)
 option(SUPPORT_FILEFORMAT_WAV "WAV Support" TRUE)
 option(SUPPORT_FILEFORMAT_OGG "OGG Support" TRUE)
 option(SUPPORT_FILEFORMAT_MP3 "MP3 Support" TRUE)
@@ -45,6 +46,11 @@ if(NOT MSVC)
     target_link_libraries(raudio
         m # math
     )
+endif()
+
+# Disable default logging option
+if (DISABLE_DEFAULT_LOG)
+    target_compile_definitions(raudio PUBLIC "RAUDIO_DISABLE_DEFAULT_LOG")
 endif()
 
 # Audio file support options

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -185,8 +185,12 @@ typedef struct tagBITMAPINFOHEADER {
 #include <string.h>                     // Required for: strcmp() [Used in IsFileExtension(), LoadWaveFromMemory(), LoadMusicStreamFromMemory()]
 
 #if defined(RAUDIO_STANDALONE)
-    #ifndef TRACELOG
-        #define TRACELOG(level, ...)    printf(__VA_ARGS__)
+    #ifndef RAUDIO_DISABLE_DEFAULT_LOG
+        #ifndef TRACELOG
+            #define TRACELOG(level, ...)    printf(__VA_ARGS__)
+        #endif
+    #else
+        #define TRACELOG(level, ...)        ((void)0)
     #endif
 
     // Allow custom memory allocators


### PR DESCRIPTION
I found that libm (-lm) was unconditionally linked in the CMake project, even if using MSVC, which doesn't have libm.
I also added an option to disable default logging in the CMake project